### PR TITLE
Fixed Musixmatch's Fourth Line Bug

### DIFF
--- a/lib/musixmatch.js
+++ b/lib/musixmatch.js
@@ -37,9 +37,9 @@ const getLyrics = url => {
             $('div[class="review-changes  review-changes__warning"]').remove();
             $('div[class="review-changes  review-changes__error"]').remove();
             $('div[class="review-changes-box"]').remove();
-            
+
             $('span span[class="lyrics__content__ok"]').append('\n');
-            
+
             if($('h2[class="mxm-empty__title"]').text() === 'Restricted Lyrics') {
                 return reject(new Error('Lyrics are restricted (nothing can be done).'));
             }

--- a/lib/musixmatch.js
+++ b/lib/musixmatch.js
@@ -33,11 +33,13 @@ const getLyrics = url => {
             $('div[class="translation-list-box"]').remove();
             $('div[class="mxm-lyrics"] div div[class="row"] div').first().remove();
             $('div[class="lyrics-to hidden-xs hidden-sm"]').remove();
-
+            
             $('div[class="review-changes  review-changes__warning"]').remove();
             $('div[class="review-changes  review-changes__error"]').remove();
             $('div[class="review-changes-box"]').remove();
-
+            
+            $('span span[class="lyrics__content__ok"]').append('\n');
+            
             if($('h2[class="mxm-empty__title"]').text() === 'Restricted Lyrics') {
                 return reject(new Error('Lyrics are restricted (nothing can be done).'));
             }

--- a/lib/musixmatch.js
+++ b/lib/musixmatch.js
@@ -37,9 +37,9 @@ const getLyrics = url => {
             $('div[class="review-changes  review-changes__warning"]').remove();
             $('div[class="review-changes  review-changes__error"]').remove();
             $('div[class="review-changes-box"]').remove();
-
+            
             $('span span[class="lyrics__content__ok"]').append('\n');
-
+            
             if($('h2[class="mxm-empty__title"]').text() === 'Restricted Lyrics') {
                 return reject(new Error('Lyrics are restricted (nothing can be done).'));
             }


### PR DESCRIPTION
Previously, the fourth line of the lyrics does not create a newline. It appends to the third line. Refer image. This has now been fixed.

![image](https://user-images.githubusercontent.com/51487578/68487438-0ae2ec00-027e-11ea-986e-7e51d4965a63.png)
